### PR TITLE
URLエンコード処理の変更

### DIFF
--- a/kskp/web/frontend/js/utils/StringUtil.js
+++ b/kskp/web/frontend/js/utils/StringUtil.js
@@ -32,11 +32,11 @@ export default class StringUtil {
   }
 
   static urlEncode(value:string):string{
-   return encodeURI(value);
+   return encodeURIComponent(value);
   }
 
   static urlDecode(value:string):string{
-    return decodeURI(value);
+    return decodeURIComponent(value);
   }
 }
 


### PR DESCRIPTION
ref. #42 
encodeURI  => encodeURIComponent に変更

encodeURIComponent の方がより正確なので再度PRを投げます。
encodeURI だとファイル名に &=123 とかが入れれてしまうので、
`#$&+,/:;=?@` もエンコードしてくれる encodeURIComponent に変更します。
