### PR TITLE
ペイン内のフォントサイズを統一 #123

### DIFF
--- a/kskp/web/frontend/js/components/shared/Input/AddButton/style.scss
+++ b/kskp/web/frontend/js/components/shared/Input/AddButton/style.scss
@@ -6,6 +6,7 @@
   cursor: pointer;
   margin: 5px;
   padding: 5px;
+  font-size: 14px;
   &:hover {
     color: darken($primary-link-color, 10%);
   }

--- a/kskp/web/frontend/js/components/shared/Inspector/BaseInspector/index.tsx
+++ b/kskp/web/frontend/js/components/shared/Inspector/BaseInspector/index.tsx
@@ -56,7 +56,7 @@ const BaseInspector = (props: Props) => {
         labelContainer = <div className={style.label}>{label}</div>;
     }
     if (subLabel) {
-        subLabelContainer = <div>
+        subLabelContainer = <div className={style.sublabel}>
             {subLabel}
         </div>;
     }

--- a/kskp/web/frontend/js/components/shared/Inspector/ParamsForm/index.tsx
+++ b/kskp/web/frontend/js/components/shared/Inspector/ParamsForm/index.tsx
@@ -167,10 +167,10 @@ export default class ParamsForm extends React.Component<Props, State> {
 
     return <React.Fragment>
       <div className={className}>
-        <div className={style.label}>
-          <span>{param.label}</span>
+        <div className={style.labelContainer}>
+          <div className={style.label}>{param.label}</div>
           <div className={style.description}>
-            <p>{param.description}</p>
+            <div>{param.description}</div>
           </div>
         </div>
         {paramElement}
@@ -184,14 +184,14 @@ export default class ParamsForm extends React.Component<Props, State> {
 
     let className = group.hide_background ? style.group : classnames(style.group, style.colored)
 
-    return <React.Fragment key={key}>
+    return <div className={"mb-12px"} key={key}>
       <div className={className}>
         {group.label}
       </div>
-      <p className={style.description}>
+      <div className={style.description}>
         {group.description}
-      </p>
-    </React.Fragment>
+      </div>
+    </div>
   }
 
 
@@ -202,7 +202,7 @@ export default class ParamsForm extends React.Component<Props, State> {
     const paramElement = this.getParamElement(param, disabled, param.label, value, onChange, headers)
     const invalidMessageEelement = this.getInvalidMessageElement(invalids[param.name])
 
-    return <div key={key} className={classnames('mb-8px', {
+    return <div key={key} className={classnames('mb-12px', {
       [style.presence]: isPresence,
       [style.invalid]: (invalidMessageEelement)
     })}>

--- a/kskp/web/frontend/js/components/shared/Inspector/ParamsForm/style.scss
+++ b/kskp/web/frontend/js/components/shared/Inspector/ParamsForm/style.scss
@@ -34,7 +34,7 @@
   margin: 16px -16px 16px -16px;
   padding: 4px 16px 4px 16px;
   height: 30px;
-  font-size: 1.2rem;
+  font-size: 14px;
 }
 
 .colored {
@@ -47,7 +47,15 @@
   word-wrap: normal;
   white-space: pre-wrap;
   color: lighten($kskp-text, 15%);
-  font-size: 13px;
-  padding: 0px 8px 0px 8px;
+  font-size: 12px;
+  padding: 0;
   margin: 0;
+}
+
+.labelContainer{
+  margin-bottom: 4px;
+}
+
+.label{
+  font-size: 14px;
 }

--- a/kskp/web/frontend/js/components/shared/Inspector/PreviewInspector/index.jsx
+++ b/kskp/web/frontend/js/components/shared/Inspector/PreviewInspector/index.jsx
@@ -74,8 +74,7 @@ class PreviewInspector extends React.Component<PreviewInspectorProps, State> {
       <div>
         <div className={style.full_hr} />
         <Button onClick={(e) => this.onClickApply(e)}>表示</Button>
-        <div>
-          <div className="kskp-form"></div>
+        <div className={"mt-12px"}>
           <ParamsForm
              key={label} 
              headers={headers} params={params} args={this.state.args} 

--- a/kskp/web/frontend/js/components/shared/Inspector/style.scss
+++ b/kskp/web/frontend/js/components/shared/Inspector/style.scss
@@ -181,7 +181,7 @@
   padding: 4px 0;
   position: relative;
   color: $kskp-text;
-  font-size: 14px;
+  font-size: 16px;
   border-bottom: 1px dotted transparent;
   &.clickable{
     &:hover {
@@ -198,6 +198,11 @@
       cursor: default;
     }
   }
+}
+
+.sublabel{
+  font-size: 14px;
+  color: #606C7A;
 }
 
 .left {


### PR DESCRIPTION
プレビュー画面のテーブルの表示ボタンの下部に余白をつける #122
も調整済み