### PR TITLE
フローエディターのペインを左右に高速にサイズ変更した場合、ペイン内の表示が消えたままになる

### DIFF
--- a/kskp/web/frontend/js/components/shared/Inspector/Resizer/index.tsx
+++ b/kskp/web/frontend/js/components/shared/Inspector/Resizer/index.tsx
@@ -110,7 +110,7 @@ class Resizer extends React.Component<Props, State> {
       const newWidth = window.innerWidth - e.pageX
       if (newWidth >= Constants.default.inspector.width && newWidth <=
         Constants.default.inspector.maxWidth) {
-        this.setState({willClosed: false, width: newWidth},
+        this.setState({isClosed: false, willClosed: false, width: newWidth},
           () => {
             //　redux 使うケース（FlowEditor)
             if (resizeInspector) resizeInspector(newWidth)


### PR DESCRIPTION
ref. #137